### PR TITLE
Fix for unset Target/Source objects

### DIFF
--- a/src/Avalonia.Xaml.Interactions/Core/CallMethodAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/CallMethodAction.cs
@@ -41,7 +41,7 @@ namespace Avalonia.Xaml.Interactions.Core
         /// Identifies the <seealso cref="TargetObject"/> avalonia property.
         /// </summary>
         public static readonly AvaloniaProperty<object> TargetObjectProperty =
-            AvaloniaProperty.Register<CallMethodAction, object>(nameof(TargetObject));
+            AvaloniaProperty.Register<CallMethodAction, object>(nameof(TargetObject), AvaloniaProperty.UnsetValue);
 
         private Type targetObjectType;
         private List<MethodDescriptor> methodDescriptors = new List<MethodDescriptor>();

--- a/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
@@ -23,7 +23,7 @@ namespace Avalonia.Xaml.Interactions.Core
         /// Identifies the <seealso cref="TargetObject"/> avalonia property.
         /// </summary>
         public static readonly AvaloniaProperty<object> TargetObjectProperty =
-            AvaloniaProperty.Register<ChangePropertyAction, object>(nameof(TargetObject));
+            AvaloniaProperty.Register<ChangePropertyAction, object>(nameof(TargetObject), AvaloniaProperty.UnsetValue);
 
         /// <summary>
         /// Identifies the <seealso cref="Value"/> avalonia property.

--- a/src/Avalonia.Xaml.Interactions/Core/EventTriggerBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/EventTriggerBehavior.cs
@@ -50,7 +50,7 @@ namespace Avalonia.Xaml.Interactions.Core
         /// Identifies the <seealso cref="SourceObject"/> avalonia property.
         /// </summary>
         public static readonly AvaloniaProperty<object> SourceObjectProperty =
-            AvaloniaProperty.Register<EventTriggerBehavior, object>(nameof(SourceObject));
+            AvaloniaProperty.Register<EventTriggerBehavior, object>(nameof(SourceObject), AvaloniaProperty.UnsetValue);
 
         private object resolvedSource;
         private Delegate eventHandler;


### PR DESCRIPTION
When applying  EventTriggerBehavior, CallMethodAction and ChangePropertyAction without setting the Target/Source objects the code is supposed to default to AttachedObject, but due to the default value of those properties being null, the comparison always fails and the behavior/actions never trigger. 

This pull request sets the default value of those properties to UnsetValue, to make sure the comparison succeeds. 