### PR TITLE
Enable nullable reference types

### DIFF
--- a/build/Base.props
+++ b/build/Base.props
@@ -8,4 +8,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/wieslawsoltes/AvaloniaBehaviors</PackageProjectUrl>
   </PropertyGroup>
+  <PropertyGroup>
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
 </Project>

--- a/samples/BehaviorsTestApplication.NetCore/BehaviorsTestApplication.NetCore.csproj
+++ b/samples/BehaviorsTestApplication.NetCore/BehaviorsTestApplication.NetCore.csproj
@@ -7,6 +7,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <PublishTrimmed>False</PublishTrimmed>
+    <PublishSingleFile>False</PublishSingleFile>
+    <PublishReadyToRun>True</PublishReadyToRun>
+  </PropertyGroup>
+
   <Import Project="..\..\build\Base.props" />
   <Import Project="..\..\build\ReferenceAssemblies.props" />
   <Import Project="..\..\build\Rx.props" />

--- a/samples/BehaviorsTestApplication.NetCore/BehaviorsTestApplication.NetCore.csproj
+++ b/samples/BehaviorsTestApplication.NetCore/BehaviorsTestApplication.NetCore.csproj
@@ -4,6 +4,7 @@
     <OutputType>WinExe</OutputType>
     <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />

--- a/samples/BehaviorsTestApplication/BehaviorsTestApplication.csproj
+++ b/samples/BehaviorsTestApplication/BehaviorsTestApplication.csproj
@@ -7,6 +7,7 @@
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <Import Project="..\..\build\Base.props" />

--- a/samples/BehaviorsTestApplication/ViewModels/Core/Command.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/Core/Command.cs
@@ -8,12 +8,14 @@ namespace BehaviorsTestApplication.ViewModels.Core
 {
     public class Command : ICommand
     {
-        private Action<object> _execute;
-        private Predicate<object> _canExecute;
+        private Action<object>? _execute;
+        private Predicate<object>? _canExecute;
 
         public event EventHandler CanExecuteChanged;
 
-        public Command(Action<object> execute = null, Predicate<object> canExecute = null)
+#pragma warning disable CS8618
+        public Command(Action<object>? execute = null, Predicate<object>? canExecute = null)
+#pragma warning restore CS8618
         {
             _execute = execute;
             _canExecute = canExecute;

--- a/samples/BehaviorsTestApplication/ViewModels/Core/ViewModelBase.cs
+++ b/samples/BehaviorsTestApplication/ViewModels/Core/ViewModelBase.cs
@@ -8,14 +8,16 @@ namespace BehaviorsTestApplication.ViewModels.Core
 {
     public abstract class ViewModelBase : INotifyPropertyChanged
     {
+#pragma warning disable CS8618
         public event PropertyChangedEventHandler PropertyChanged;
+#pragma warning restore CS8618
 
-        public void Notify([CallerMemberName] string propertyName = null)
+        public void Notify([CallerMemberName] string propertyName = "")
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
 
-        public bool Update<T>(ref T field, T value, [CallerMemberName] string propertyName = null)
+        public bool Update<T>(ref T field, T value, [CallerMemberName] string propertyName = "")
         {
             if (!Equals(field, value))
             {

--- a/src/Avalonia.Xaml.Behaviors/Avalonia.Xaml.Behaviors.csproj
+++ b/src/Avalonia.Xaml.Behaviors/Avalonia.Xaml.Behaviors.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <IncludeBuildOutput>False</IncludeBuildOutput>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Avalonia.Xaml.Behaviors/Avalonia.Xaml.Behaviors.csproj
+++ b/src/Avalonia.Xaml.Behaviors/Avalonia.Xaml.Behaviors.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <IncludeBuildOutput>False</IncludeBuildOutput>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Avalonia.Xaml.Interactions.Custom/Avalonia.Xaml.Interactions.Custom.csproj
+++ b/src/Avalonia.Xaml.Interactions.Custom/Avalonia.Xaml.Interactions.Custom.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/src/Avalonia.Xaml.Interactions.Custom/Avalonia.Xaml.Interactions.Custom.csproj
+++ b/src/Avalonia.Xaml.Interactions.Custom/Avalonia.Xaml.Interactions.Custom.csproj
@@ -6,6 +6,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Avalonia.Xaml.Interactions.Custom/BindTagToVisualRootDataContextBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/BindTagToVisualRootDataContextBehavior.cs
@@ -19,14 +19,20 @@ namespace Avalonia.Xaml.Interactions.Custom
         protected override void OnAttached()
         {
             base.OnAttached();
-            AssociatedObject.AttachedToVisualTree += AttachedToVisualTree;
+            if (AssociatedObject != null)
+            {
+                AssociatedObject.AttachedToVisualTree += AttachedToVisualTree; 
+            }
         }
 
         /// <inheritdoc/>
         protected override void OnDetaching()
         {
             base.OnDetaching();
-            AssociatedObject.AttachedToVisualTree -= AttachedToVisualTree;
+            if (AssociatedObject != null)
+            {
+                AssociatedObject.AttachedToVisualTree -= AttachedToVisualTree; 
+            }
             _disposable?.Dispose();
         }
 
@@ -35,7 +41,7 @@ namespace Avalonia.Xaml.Interactions.Custom
             _disposable = BindDataContextToTag((IControl)AssociatedObject.GetVisualRoot(), AssociatedObject);
         }
 
-        private static IDisposable BindDataContextToTag(IControl source, IControl target)
+        private static IDisposable? BindDataContextToTag(IControl source, IControl? target)
         {
             if (source == null)
                 throw new ArgumentNullException(nameof(source));

--- a/src/Avalonia.Xaml.Interactions.Custom/BindTagToVisualRootDataContextBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/BindTagToVisualRootDataContextBehavior.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Xaml.Interactions.Custom
     /// </summary>
     public sealed class BindTagToVisualRootDataContextBehavior : Behavior<Control>
     {
-        private IDisposable _disposable;
+        private IDisposable? _disposable;
 
         /// <inheritdoc/>
         protected override void OnAttached()

--- a/src/Avalonia.Xaml.Interactions.Custom/DragPositionBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/DragPositionBehavior.cs
@@ -13,7 +13,7 @@ namespace Avalonia.Xaml.Interactions.Custom
     /// </summary>
     public sealed class DragPositionBehavior : Behavior<Control>
     {
-        private IControl _parent = null;
+        private IControl? _parent = null;
         private Point _previous;
 
         /// <summary>
@@ -22,7 +22,10 @@ namespace Avalonia.Xaml.Interactions.Custom
         protected override void OnAttached()
         {
             base.OnAttached();
-            AssociatedObject.PointerPressed += AssociatedObject_PointerPressed;
+            if (AssociatedObject != null)
+            {
+                AssociatedObject.PointerPressed += AssociatedObject_PointerPressed; 
+            }
         }
 
         /// <summary>
@@ -31,38 +34,52 @@ namespace Avalonia.Xaml.Interactions.Custom
         protected override void OnDetaching()
         {
             base.OnDetaching();
-            AssociatedObject.PointerPressed -= AssociatedObject_PointerPressed;
+            if (AssociatedObject != null)
+            {
+                AssociatedObject.PointerPressed -= AssociatedObject_PointerPressed; 
+            }
             _parent = null;
         }
 
         private void AssociatedObject_PointerPressed(object sender, PointerPressedEventArgs e)
         {
-            _parent = AssociatedObject.Parent;
-
-            if (!(AssociatedObject.RenderTransform is TranslateTransform))
+            if (AssociatedObject != null)
             {
-                AssociatedObject.RenderTransform = new TranslateTransform();
-            }
+                _parent = AssociatedObject.Parent;
 
-            _previous = e.GetPosition(_parent);
-            _parent.PointerMoved += Parent_PointerMoved;
-            _parent.PointerReleased += Parent_PointerReleased;
+                if (!(AssociatedObject.RenderTransform is TranslateTransform))
+                {
+                    AssociatedObject.RenderTransform = new TranslateTransform();
+                }
+
+                _previous = e.GetPosition(_parent);
+                _parent.PointerMoved += Parent_PointerMoved;
+                _parent.PointerReleased += Parent_PointerReleased; 
+            }
         }
 
         private void Parent_PointerMoved(object sender, PointerEventArgs args)
         {
-            var pos = args.GetPosition(_parent);
-            var tr = (TranslateTransform)AssociatedObject.RenderTransform;
-            tr.X += pos.X - _previous.X;
-            tr.Y += pos.Y - _previous.Y;
-            _previous = pos;
+            if (AssociatedObject != null)
+            {
+                var pos = args.GetPosition(_parent);
+                if (AssociatedObject.RenderTransform is TranslateTransform tr)
+                {
+                    tr.X += pos.X - _previous.X;
+                    tr.Y += pos.Y - _previous.Y;
+                }
+                _previous = pos; 
+            }
         }
 
         private void Parent_PointerReleased(object sender, PointerReleasedEventArgs e)
         {
-            _parent.PointerMoved -= Parent_PointerMoved;
-            _parent.PointerReleased -= Parent_PointerReleased;
-            _parent = null;
+            if (_parent != null)
+            {
+                _parent.PointerMoved -= Parent_PointerMoved;
+                _parent.PointerReleased -= Parent_PointerReleased;
+                _parent = null; 
+            }
         }
     }
 }

--- a/src/Avalonia.Xaml.Interactions.Custom/FocusControlAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/FocusControlAction.cs
@@ -17,7 +17,7 @@ namespace Avalonia.Xaml.Interactions.Custom
         /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="IBehavior.AssociatedObject"/> or a target object.</param>
         /// <param name="parameter">The value of this parameter is determined by the caller.</param>
         /// <returns>Returns null after executed.</returns>
-        public object Execute(object sender, object parameter)
+        public object? Execute(object sender, object parameter)
         {
             (sender as Control)?.Focus();
             return null;

--- a/src/Avalonia.Xaml.Interactions.Custom/FocusControlAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/FocusControlAction.cs
@@ -17,7 +17,7 @@ namespace Avalonia.Xaml.Interactions.Custom
         /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="IBehavior.AssociatedObject"/> or a target object.</param>
         /// <param name="parameter">The value of this parameter is determined by the caller.</param>
         /// <returns>Returns null after executed.</returns>
-        public object? Execute(object sender, object parameter)
+        public object? Execute(object? sender, object? parameter)
         {
             (sender as Control)?.Focus();
             return null;

--- a/src/Avalonia.Xaml.Interactions.Custom/FocusOnAttachedToVisualTreeBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/FocusOnAttachedToVisualTreeBehavior.cs
@@ -17,7 +17,10 @@ namespace Avalonia.Xaml.Interactions.Custom
         protected override void OnAttached()
         {
             base.OnAttached();
-            AssociatedObject.AttachedToVisualTree += AttachedToVisualTree;
+            if (AssociatedObject != null)
+            {
+                AssociatedObject.AttachedToVisualTree += AttachedToVisualTree; 
+            }
         }
 
         /// <summary>
@@ -26,12 +29,15 @@ namespace Avalonia.Xaml.Interactions.Custom
         protected override void OnDetaching()
         {
             base.OnDetaching();
-            AssociatedObject.AttachedToVisualTree -= AttachedToVisualTree;
+            if (AssociatedObject != null)
+            {
+                AssociatedObject.AttachedToVisualTree -= AttachedToVisualTree; 
+            }
         }
 
         private void AttachedToVisualTree(object sender, VisualTreeAttachmentEventArgs e)
         {
-            AssociatedObject.Focus();
+            AssociatedObject?.Focus();
         }
     }
 }

--- a/src/Avalonia.Xaml.Interactions.Custom/FocusOnPointerMovedBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/FocusOnPointerMovedBehavior.cs
@@ -18,7 +18,10 @@ namespace Avalonia.Xaml.Interactions.Custom
         protected override void OnAttached()
         {
             base.OnAttached();
-            AssociatedObject.PointerMoved += PointerMoved;
+            if (AssociatedObject != null)
+            {
+                AssociatedObject.PointerMoved += PointerMoved; 
+            }
         }
 
         /// <summary>
@@ -27,12 +30,15 @@ namespace Avalonia.Xaml.Interactions.Custom
         protected override void OnDetaching()
         {
             base.OnDetaching();
-            AssociatedObject.PointerMoved -= PointerMoved;
+            if (AssociatedObject != null)
+            {
+                AssociatedObject.PointerMoved -= PointerMoved; 
+            }
         }
 
         private void PointerMoved(object sender, PointerEventArgs args)
         {
-            AssociatedObject.Focus();
+            AssociatedObject?.Focus();
         }
     }
 }

--- a/src/Avalonia.Xaml.Interactions.Custom/FocusOnPointerPressedBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/FocusOnPointerPressedBehavior.cs
@@ -18,7 +18,10 @@ namespace Avalonia.Xaml.Interactions.Custom
         protected override void OnAttached()
         {
             base.OnAttached();
-            AssociatedObject.PointerPressed += PointerPressed;
+            if (AssociatedObject != null)
+            {
+                AssociatedObject.PointerPressed += PointerPressed; 
+            }
         }
 
         /// <summary>
@@ -27,12 +30,15 @@ namespace Avalonia.Xaml.Interactions.Custom
         protected override void OnDetaching()
         {
             base.OnDetaching();
-            AssociatedObject.PointerPressed -= PointerPressed;
+            if (AssociatedObject != null)
+            {
+                AssociatedObject.PointerPressed -= PointerPressed; 
+            }
         }
 
         private void PointerPressed(object sender, PointerPressedEventArgs e)
         {
-            AssociatedObject.Focus();
+            AssociatedObject?.Focus();
         }
     }
 }

--- a/src/Avalonia.Xaml.Interactions.Custom/PopupAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/PopupAction.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Xaml.Interactions.Custom
     /// <remarks>If the associated control is of type <see cref="IControl"/> than popup inherits control <see cref="StyledElement.DataContext"/>.</remarks>
     public sealed class PopupAction : AvaloniaObject, IAction
     {
-        private Popup _popup = null;
+        private Popup? _popup = null;
 
         /// <summary>
         /// Identifies the <seealso cref="ChildProperty"/> avalonia property.
@@ -39,7 +39,7 @@ namespace Avalonia.Xaml.Interactions.Custom
         /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="IBehavior.AssociatedObject"/> or a target object.</param>
         /// <param name="parameter">The value of this parameter is determined by the caller.</param>
         /// <returns>Returns null after executed.</returns>
-        public object Execute(object sender, object parameter)
+        public object? Execute(object sender, object parameter)
         {
             if (_popup == null)
             {

--- a/src/Avalonia.Xaml.Interactions.Custom/PopupAction.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/PopupAction.cs
@@ -39,7 +39,7 @@ namespace Avalonia.Xaml.Interactions.Custom
         /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="IBehavior.AssociatedObject"/> or a target object.</param>
         /// <param name="parameter">The value of this parameter is determined by the caller.</param>
         /// <returns>Returns null after executed.</returns>
-        public object? Execute(object sender, object parameter)
+        public object? Execute(object? sender, object? parameter)
         {
             if (_popup == null)
             {

--- a/src/Avalonia.Xaml.Interactions.Custom/SelectListBoxItemOnPointerMovedBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/SelectListBoxItemOnPointerMovedBehavior.cs
@@ -18,7 +18,10 @@ namespace Avalonia.Xaml.Interactions.Custom
         protected override void OnAttached()
         {
             base.OnAttached();
-            AssociatedObject.PointerMoved += PointerMoved;
+            if (AssociatedObject != null)
+            {
+                AssociatedObject.PointerMoved += PointerMoved; 
+            }
         }
 
         /// <summary>
@@ -27,12 +30,15 @@ namespace Avalonia.Xaml.Interactions.Custom
         protected override void OnDetaching()
         {
             base.OnDetaching();
-            AssociatedObject.PointerMoved -= PointerMoved;
+            if (AssociatedObject != null)
+            {
+                AssociatedObject.PointerMoved -= PointerMoved; 
+            }
         }
 
         private void PointerMoved(object sender, PointerEventArgs args)
         {
-            if (AssociatedObject.Parent is ListBoxItem item)
+            if (AssociatedObject != null && AssociatedObject.Parent is ListBoxItem item)
             {
                 item.IsSelected = true;
                 item.Focus();

--- a/src/Avalonia.Xaml.Interactions.Custom/ShowPointerPositionBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/ShowPointerPositionBehavior.cs
@@ -33,7 +33,10 @@ namespace Avalonia.Xaml.Interactions.Custom
         protected override void OnAttached()
         {
             base.OnAttached();
-            AssociatedObject.PointerMoved += AssociatedObject_PointerMoved;
+            if (AssociatedObject != null)
+            {
+                AssociatedObject.PointerMoved += AssociatedObject_PointerMoved; 
+            }
         }
 
         /// <summary>
@@ -42,7 +45,10 @@ namespace Avalonia.Xaml.Interactions.Custom
         protected override void OnDetaching()
         {
             base.OnDetaching();
-            AssociatedObject.PointerMoved -= AssociatedObject_PointerMoved;
+            if (AssociatedObject != null)
+            {
+                AssociatedObject.PointerMoved -= AssociatedObject_PointerMoved; 
+            }
         }
 
         private void AssociatedObject_PointerMoved(object sender, PointerEventArgs e)

--- a/src/Avalonia.Xaml.Interactions.Custom/ToggleIsExpandedOnDoubleTappedBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions.Custom/ToggleIsExpandedOnDoubleTappedBehavior.cs
@@ -19,7 +19,10 @@ namespace Avalonia.Xaml.Interactions.Custom
         protected override void OnAttached()
         {
             base.OnAttached();
-            AssociatedObject.DoubleTapped += DoubleTapped;
+            if (AssociatedObject != null)
+            {
+                AssociatedObject.DoubleTapped += DoubleTapped; 
+            }
         }
 
         /// <summary>
@@ -28,12 +31,15 @@ namespace Avalonia.Xaml.Interactions.Custom
         protected override void OnDetaching()
         {
             base.OnDetaching();
-            AssociatedObject.DoubleTapped -= DoubleTapped;
+            if (AssociatedObject != null)
+            {
+                AssociatedObject.DoubleTapped -= DoubleTapped; 
+            }
         }
 
         private void DoubleTapped(object sender, RoutedEventArgs args)
         {
-            if (AssociatedObject.Parent is TreeViewItem item)
+            if (AssociatedObject != null && AssociatedObject.Parent is TreeViewItem item)
             {
                 item.IsExpanded = !item.IsExpanded;
             }

--- a/src/Avalonia.Xaml.Interactions/Avalonia.Xaml.Interactions.csproj
+++ b/src/Avalonia.Xaml.Interactions/Avalonia.Xaml.Interactions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/src/Avalonia.Xaml.Interactions/Avalonia.Xaml.Interactions.csproj
+++ b/src/Avalonia.Xaml.Interactions/Avalonia.Xaml.Interactions.csproj
@@ -6,6 +6,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Avalonia.Xaml.Interactions/Core/CallMethodAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/CallMethodAction.cs
@@ -26,8 +26,11 @@ namespace Avalonia.Xaml.Interactions.Core
             TargetObjectProperty.Changed.Subscribe(e =>
             {
                 CallMethodAction callMethodAction = (CallMethodAction)e.Sender;
-                Type newType = e.NewValue?.GetType();
-                callMethodAction.UpdateTargetType(newType);
+                if (e.NewValue != null)
+                {
+                    Type newType = e.NewValue.GetType();
+                    callMethodAction.UpdateTargetType(newType); 
+                }
             });
         }
 
@@ -43,9 +46,9 @@ namespace Avalonia.Xaml.Interactions.Core
         public static readonly AvaloniaProperty<object> TargetObjectProperty =
             AvaloniaProperty.Register<CallMethodAction, object>(nameof(TargetObject), AvaloniaProperty.UnsetValue);
 
-        private Type targetObjectType;
+        private Type? targetObjectType;
         private List<MethodDescriptor> methodDescriptors = new List<MethodDescriptor>();
-        private MethodDescriptor cachedMethodDescriptor;
+        private MethodDescriptor? cachedMethodDescriptor;
 
         /// <summary>
         /// Gets or sets the name of the method to invoke. This is a avalonia property.
@@ -90,7 +93,7 @@ namespace Avalonia.Xaml.Interactions.Core
 
             UpdateTargetType(target.GetType());
 
-            MethodDescriptor methodDescriptor = FindBestMethod(parameter);
+            MethodDescriptor? methodDescriptor = FindBestMethod(parameter);
             if (methodDescriptor == null)
             {
                 if (TargetObject != null)
@@ -120,23 +123,23 @@ namespace Avalonia.Xaml.Interactions.Core
             return false;
         }
 
-        private MethodDescriptor FindBestMethod(object parameter)
+        private MethodDescriptor? FindBestMethod(object parameter)
         {
-            TypeInfo parameterTypeInfo = parameter?.GetType().GetTypeInfo();
+            TypeInfo parameterTypeInfo = parameter.GetType().GetTypeInfo();
 
             if (parameterTypeInfo == null)
             {
                 return cachedMethodDescriptor;
             }
 
-            MethodDescriptor mostDerivedMethod = null;
+            MethodDescriptor? mostDerivedMethod = null;
 
             // Loop over the methods looking for the one whose type is closest to the type of the given parameter.
             foreach (MethodDescriptor currentMethod in methodDescriptors)
             {
-                TypeInfo currentTypeInfo = currentMethod.SecondParameterTypeInfo;
+                TypeInfo? currentTypeInfo = currentMethod.SecondParameterTypeInfo;
 
-                if (currentTypeInfo.IsAssignableFrom(parameterTypeInfo))
+                if (currentTypeInfo != null && currentTypeInfo.IsAssignableFrom(parameterTypeInfo))
                 {
                     if (mostDerivedMethod == null || !currentTypeInfo.IsAssignableFrom(mostDerivedMethod.SecondParameterTypeInfo))
                     {
@@ -198,8 +201,8 @@ namespace Avalonia.Xaml.Interactions.Core
             {
                 foreach (MethodDescriptor method in methodDescriptors)
                 {
-                    TypeInfo typeInfo = method.SecondParameterTypeInfo;
-                    if (!typeInfo.IsValueType || (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Nullable<>)))
+                    TypeInfo? typeInfo = method.SecondParameterTypeInfo;
+                    if (typeInfo != null && (!typeInfo.IsValueType || (typeInfo.IsGenericType && typeInfo.GetGenericTypeDefinition() == typeof(Nullable<>))))
                     {
                         if (cachedMethodDescriptor != null)
                         {
@@ -230,7 +233,7 @@ namespace Avalonia.Xaml.Interactions.Core
 
             public int ParameterCount => Parameters.Length;
 
-            public TypeInfo SecondParameterTypeInfo
+            public TypeInfo? SecondParameterTypeInfo
             {
                 get
                 {

--- a/src/Avalonia.Xaml.Interactions/Core/CallMethodAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/CallMethodAction.cs
@@ -74,7 +74,7 @@ namespace Avalonia.Xaml.Interactions.Core
         /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="IBehavior.AssociatedObject"/> or a target object.</param>
         /// <param name="parameter">The value of this parameter is determined by the caller.</param>
         /// <returns>True if the method is called; else false.</returns>
-        public object Execute(object sender, object parameter)
+        public object? Execute(object sender, object parameter)
         {
             object target;
             if (GetValue(TargetObjectProperty) != AvaloniaProperty.UnsetValue)

--- a/src/Avalonia.Xaml.Interactions/Core/CallMethodAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/CallMethodAction.cs
@@ -74,9 +74,9 @@ namespace Avalonia.Xaml.Interactions.Core
         /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="IBehavior.AssociatedObject"/> or a target object.</param>
         /// <param name="parameter">The value of this parameter is determined by the caller.</param>
         /// <returns>True if the method is called; else false.</returns>
-        public object? Execute(object sender, object parameter)
+        public object? Execute(object? sender, object? parameter)
         {
-            object target;
+            object? target;
             if (GetValue(TargetObjectProperty) != AvaloniaProperty.UnsetValue)
             {
                 target = TargetObject;
@@ -116,15 +116,20 @@ namespace Avalonia.Xaml.Interactions.Core
             }
             else if (parameters.Length == 2)
             {
-                methodDescriptor.MethodInfo.Invoke(target, new object[] { target, parameter });
+                methodDescriptor.MethodInfo.Invoke(target, new object[] { target, parameter! });
                 return true;
             }
 
             return false;
         }
 
-        private MethodDescriptor? FindBestMethod(object parameter)
+        private MethodDescriptor? FindBestMethod(object? parameter)
         {
+            if (parameter == null)
+            {
+                return cachedMethodDescriptor;
+            }
+
             TypeInfo parameterTypeInfo = parameter.GetType().GetTypeInfo();
 
             if (parameterTypeInfo == null)

--- a/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
@@ -65,7 +65,7 @@ namespace Avalonia.Xaml.Interactions.Core
         /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="IBehavior.AssociatedObject"/> or a target object.</param>
         /// <param name="parameter">The value of this parameter is determined by the caller.</param>
         /// <returns>True if updating the property value succeeds; else false.</returns>
-        public object Execute(object sender, object parameter)
+        public object? Execute(object sender, object parameter)
         {
             object targetObject;
             if (GetValue(TargetObjectProperty) != AvaloniaProperty.UnsetValue)

--- a/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
@@ -102,11 +102,11 @@ namespace Avalonia.Xaml.Interactions.Core
             PropertyInfo propertyInfo = targetType.GetRuntimeProperty(PropertyName);
             ValidateProperty(targetType.Name, propertyInfo);
 
-            Exception innerException = null;
+            Exception? innerException = null;
             try
             {
-                object result = null;
-                string valueAsString = null;
+                object? result = null;
+                string? valueAsString = null;
                 Type propertyType = propertyInfo.PropertyType;
                 TypeInfo propertyTypeInfo = propertyType.GetTypeInfo();
                 if (Value == null)
@@ -175,11 +175,11 @@ namespace Avalonia.Xaml.Interactions.Core
         {
             ValidateAvaloniaProperty(property);
 
-            Exception innerException = null;
+            Exception? innerException = null;
             try
             {
-                object result = null;
-                string valueAsString = null;
+                object? result = null;
+                string? valueAsString = null;
                 Type propertyType = property.PropertyType;
                 TypeInfo propertyTypeInfo = propertyType.GetTypeInfo();
                 if (Value == null)

--- a/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
@@ -65,9 +65,9 @@ namespace Avalonia.Xaml.Interactions.Core
         /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="IBehavior.AssociatedObject"/> or a target object.</param>
         /// <param name="parameter">The value of this parameter is determined by the caller.</param>
         /// <returns>True if updating the property value succeeds; else false.</returns>
-        public object? Execute(object sender, object parameter)
+        public object? Execute(object? sender, object? parameter)
         {
-            object targetObject;
+            object? targetObject;
             if (GetValue(TargetObjectProperty) != AvaloniaProperty.UnsetValue)
             {
                 targetObject = TargetObject;

--- a/src/Avalonia.Xaml.Interactions/Core/DataBindingHelper.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/DataBindingHelper.cs
@@ -21,8 +21,12 @@ namespace Avalonia.Xaml.Interactions.Core
         /// bindings on the action  may not be up-to-date. This routine is called before the action
         /// is executed in order to guarantee that all bindings are refreshed with the most current data.
         /// </remarks>
-        public static void RefreshDataBindingsOnActions(ActionCollection actions)
+        public static void RefreshDataBindingsOnActions(ActionCollection? actions)
         {
+            if (actions == null)
+            {
+                return;
+            }
             foreach (AvaloniaObject action in actions)
             {
                 foreach (AvaloniaProperty property in GetAvaloniaProperties(action.GetType()))
@@ -54,7 +58,10 @@ namespace Avalonia.Xaml.Interactions.Core
                     type = type.GetTypeInfo().BaseType;
                 }
 
-                AvaloniaPropertyCache[type] = propertyList;
+                if (type != null)
+                {
+                    AvaloniaPropertyCache[type] = propertyList; 
+                }
             }
 
             return propertyList;

--- a/src/Avalonia.Xaml.Interactions/Core/DataTriggerBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/DataTriggerBehavior.cs
@@ -64,15 +64,15 @@ namespace Avalonia.Xaml.Interactions.Core
             set => SetValue(ValueProperty, value);
         }
 
-        private static bool Compare(object leftOperand, ComparisonConditionType operatorType, object rightOperand)
+        private static bool Compare(object? leftOperand, ComparisonConditionType operatorType, object? rightOperand)
         {
             if (leftOperand != null && rightOperand != null)
             {
                 rightOperand = TypeConverterHelper.Convert(rightOperand.ToString(), leftOperand.GetType());
             }
 
-            IComparable leftComparableOperand = leftOperand as IComparable;
-            IComparable rightComparableOperand = rightOperand as IComparable;
+            IComparable? leftComparableOperand = leftOperand as IComparable;
+            IComparable? rightComparableOperand = rightOperand as IComparable;
             if ((leftComparableOperand != null) && (rightComparableOperand != null))
             {
                 return EvaluateComparable(leftComparableOperand, operatorType, rightComparableOperand);
@@ -127,7 +127,7 @@ namespace Avalonia.Xaml.Interactions.Core
         /// </summary>
         private static bool EvaluateComparable(IComparable leftOperand, ComparisonConditionType operatorType, IComparable rightOperand)
         {
-            object convertedOperand = null;
+            object? convertedOperand = null;
             try
             {
                 convertedOperand = Convert.ChangeType(rightOperand, leftOperand.GetType(), CultureInfo.CurrentCulture);

--- a/src/Avalonia.Xaml.Interactions/Core/InvokeCommandAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/InvokeCommandAction.cs
@@ -101,7 +101,7 @@ namespace Avalonia.Xaml.Interactions.Core
         /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="IBehavior.AssociatedObject"/> or a target object.</param>
         /// <param name="parameter">The value of this parameter is determined by the caller.</param>
         /// <returns>True if the command is successfully executed; else false.</returns>
-        public object Execute(object sender, object parameter)
+        public object? Execute(object sender, object parameter)
         {
             if (Command == null)
             {

--- a/src/Avalonia.Xaml.Interactions/Core/InvokeCommandAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/InvokeCommandAction.cs
@@ -101,14 +101,14 @@ namespace Avalonia.Xaml.Interactions.Core
         /// <param name="sender">The <see cref="object"/> that is passed to the action by the behavior. Generally this is <seealso cref="IBehavior.AssociatedObject"/> or a target object.</param>
         /// <param name="parameter">The value of this parameter is determined by the caller.</param>
         /// <returns>True if the command is successfully executed; else false.</returns>
-        public object? Execute(object sender, object parameter)
+        public object? Execute(object? sender, object? parameter)
         {
             if (Command == null)
             {
                 return false;
             }
 
-            object resolvedParameter;
+            object? resolvedParameter;
             if (CommandParameter != null)
             {
                 resolvedParameter = CommandParameter;

--- a/src/Avalonia.Xaml.Interactions/Core/TypeConverterHelper.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/TypeConverterHelper.cs
@@ -19,7 +19,7 @@ namespace Avalonia.Xaml.Interactions.Core
         /// <param name="destinationType">The destination type.</param>
         /// <returns>Object representation of the string value.</returns>
         /// <exception cref="ArgumentNullException">destinationType cannot be null.</exception>
-        public static object Convert(string value, Type destinationType)
+        public static object? Convert(string value, Type destinationType)
         {
             if (destinationType == null)
             {

--- a/src/Avalonia.Xaml.Interactivity/Avalonia.Xaml.Interactivity.csproj
+++ b/src/Avalonia.Xaml.Interactivity/Avalonia.Xaml.Interactivity.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <OutputType>Library</OutputType>
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/src/Avalonia.Xaml.Interactivity/Avalonia.Xaml.Interactivity.csproj
+++ b/src/Avalonia.Xaml.Interactivity/Avalonia.Xaml.Interactivity.csproj
@@ -6,6 +6,7 @@
     <EnableDefaultCompileItems>False</EnableDefaultCompileItems>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Avalonia.Xaml.Interactivity/Behavior.cs
+++ b/src/Avalonia.Xaml.Interactivity/Behavior.cs
@@ -15,14 +15,14 @@ namespace Avalonia.Xaml.Interactivity
         /// <summary>
         /// Gets the <see cref="AvaloniaObject"/> to which the behavior is attached.
         /// </summary>
-        public AvaloniaObject AssociatedObject { get; private set; }
+        public AvaloniaObject? AssociatedObject { get; private set; }
 
         /// <summary>
         /// Attaches the behavior to the specified <see cref="AvaloniaObject"/>.
         /// </summary>
         /// <param name="associatedObject">The <see cref="AvaloniaObject"/> to which to attach.</param>
         /// <exception cref="ArgumentNullException"><paramref name="associatedObject"/> is null.</exception>
-        public void Attach(AvaloniaObject associatedObject)
+        public void Attach(AvaloniaObject? associatedObject)
         {
             if (associatedObject == AssociatedObject)
             {

--- a/src/Avalonia.Xaml.Interactivity/BehaviorCollection.cs
+++ b/src/Avalonia.Xaml.Interactivity/BehaviorCollection.cs
@@ -29,7 +29,7 @@ namespace Avalonia.Xaml.Interactivity
         /// <summary>
         /// Gets the <see cref="AvaloniaObject"/> to which the <see cref="BehaviorCollection"/> is attached.
         /// </summary>
-        public AvaloniaObject AssociatedObject
+        public AvaloniaObject? AssociatedObject
         {
             get;
             private set;
@@ -40,7 +40,7 @@ namespace Avalonia.Xaml.Interactivity
         /// </summary>
         /// <param name="associatedObject">The <see cref="AvaloniaObject"/> to which to attach.</param>
         /// <exception cref="InvalidOperationException">The <see cref="BehaviorCollection"/> is already attached to a different <see cref="AvaloniaObject"/>.</exception>
-        public void Attach(AvaloniaObject associatedObject)
+        public void Attach(AvaloniaObject? associatedObject)
         {
             if (associatedObject == AssociatedObject)
             {
@@ -155,10 +155,9 @@ namespace Avalonia.Xaml.Interactivity
 #endif
         }
 
-        private IBehavior VerifiedAttach(AvaloniaObject item)
+        private IBehavior VerifiedAttach(AvaloniaObject? item)
         {
-            IBehavior behavior = item as IBehavior;
-            if (behavior == null)
+            if (!(item is IBehavior behavior))
             {
                 throw new InvalidOperationException("Only IBehavior types are supported in a BehaviorCollection.");
             }

--- a/src/Avalonia.Xaml.Interactivity/BehaviorOfT.cs
+++ b/src/Avalonia.Xaml.Interactivity/BehaviorOfT.cs
@@ -11,12 +11,12 @@ namespace Avalonia.Xaml.Interactivity
     /// and allow for typed associated objects.
     /// </summary>
     /// <typeparam name="T">The object type to attach to</typeparam>
-    public abstract class Behavior<T> : Behavior where T : AvaloniaObject
+    public abstract class Behavior<T> : Behavior where T : notnull, AvaloniaObject
     {
         /// <summary>
         /// Gets the object to which this behavior is attached.
         /// </summary>
-        public new T AssociatedObject => base.AssociatedObject as T;
+        public new T? AssociatedObject => base.AssociatedObject as T;
 
         /// <summary>
         /// Called after the behavior is attached to the <see cref="Behavior.AssociatedObject"/>.
@@ -28,7 +28,7 @@ namespace Avalonia.Xaml.Interactivity
         {
             base.OnAttached();
 
-            if (AssociatedObject == null)
+            if (AssociatedObject == null && base.AssociatedObject != null)
             {
                 string actualType = base.AssociatedObject.GetType().FullName;
                 string expectedType = typeof(T).FullName;

--- a/src/Avalonia.Xaml.Interactivity/BehaviorOfT.cs
+++ b/src/Avalonia.Xaml.Interactivity/BehaviorOfT.cs
@@ -11,7 +11,7 @@ namespace Avalonia.Xaml.Interactivity
     /// and allow for typed associated objects.
     /// </summary>
     /// <typeparam name="T">The object type to attach to</typeparam>
-    public abstract class Behavior<T> : Behavior where T : notnull, AvaloniaObject
+    public abstract class Behavior<T> : Behavior where T : AvaloniaObject
     {
         /// <summary>
         /// Gets the object to which this behavior is attached.

--- a/src/Avalonia.Xaml.Interactivity/IAction.cs
+++ b/src/Avalonia.Xaml.Interactivity/IAction.cs
@@ -15,6 +15,6 @@ namespace Avalonia.Xaml.Interactivity
         /// <param name="parameter">The value of this parameter is determined by the caller.</param>
         /// <remarks> An example of parameter usage is EventTriggerBehavior, which passes the EventArgs as a parameter to its actions.</remarks>
         /// <returns>Returns the result of the action.</returns>
-        object Execute(object sender, object parameter);
+        object? Execute(object sender, object parameter);
     }
 }

--- a/src/Avalonia.Xaml.Interactivity/IAction.cs
+++ b/src/Avalonia.Xaml.Interactivity/IAction.cs
@@ -15,6 +15,6 @@ namespace Avalonia.Xaml.Interactivity
         /// <param name="parameter">The value of this parameter is determined by the caller.</param>
         /// <remarks> An example of parameter usage is EventTriggerBehavior, which passes the EventArgs as a parameter to its actions.</remarks>
         /// <returns>Returns the result of the action.</returns>
-        object? Execute(object sender, object parameter);
+        object? Execute(object? sender, object? parameter);
     }
 }

--- a/src/Avalonia.Xaml.Interactivity/IBehavior.cs
+++ b/src/Avalonia.Xaml.Interactivity/IBehavior.cs
@@ -11,13 +11,13 @@ namespace Avalonia.Xaml.Interactivity
         /// <summary>
         /// Gets the <see cref="AvaloniaObject"/> to which the <seealso cref="IBehavior"/> is attached.
         /// </summary>
-        AvaloniaObject AssociatedObject { get; }
+        AvaloniaObject? AssociatedObject { get; }
 
         /// <summary>
         /// Attaches to the specified object.
         /// </summary>
         /// <param name="associatedObject">The <see cref="AvaloniaObject"/> to which the <seealso cref="IBehavior"/> will be attached.</param>
-        void Attach(AvaloniaObject associatedObject);
+        void Attach(AvaloniaObject? associatedObject);
 
         /// <summary>
         /// Detaches this instance from its associated object.

--- a/src/Avalonia.Xaml.Interactivity/ITrigger.cs
+++ b/src/Avalonia.Xaml.Interactivity/ITrigger.cs
@@ -11,6 +11,6 @@ namespace Avalonia.Xaml.Interactivity
         /// <summary>
         /// Gets the collection of actions associated with the behavior.
         /// </summary>
-        ActionCollection Actions { get; }
+        ActionCollection? Actions { get; }
     }
 }

--- a/src/Avalonia.Xaml.Interactivity/Interaction.cs
+++ b/src/Avalonia.Xaml.Interactivity/Interaction.cs
@@ -97,7 +97,7 @@ namespace Avalonia.Xaml.Interactivity
         {
             List<object> results = new List<object>();
 
-            if (actions == null || sender == null)
+            if (actions == null)
             {
                 return results;
             }

--- a/src/Avalonia.Xaml.Interactivity/Interaction.cs
+++ b/src/Avalonia.Xaml.Interactivity/Interaction.cs
@@ -105,7 +105,11 @@ namespace Avalonia.Xaml.Interactivity
             foreach (AvaloniaObject avaloniaObject in actions)
             {
                 IAction action = (IAction)avaloniaObject;
-                results.Add(action.Execute(sender, parameter));
+                object? result = action.Execute(sender, parameter);
+                if (result != null)
+                {
+                    results.Add(result);
+                }
             }
 
             return results;

--- a/src/Avalonia.Xaml.Interactivity/Interaction.cs
+++ b/src/Avalonia.Xaml.Interactivity/Interaction.cs
@@ -93,11 +93,11 @@ namespace Avalonia.Xaml.Interactivity
         /// <param name="actions">The set of actions to execute.</param>
         /// <param name="parameter">The value of this parameter is determined by the calling behavior.</param>
         /// <returns>Returns the results of the actions.</returns>
-        public static IEnumerable<object> ExecuteActions(object sender, ActionCollection actions, object parameter)
+        public static IEnumerable<object> ExecuteActions(object? sender, ActionCollection? actions, object parameter)
         {
             List<object> results = new List<object>();
 
-            if (actions == null)
+            if (actions == null || sender == null)
             {
                 return results;
             }

--- a/src/Avalonia.Xaml.Interactivity/Interaction.cs
+++ b/src/Avalonia.Xaml.Interactivity/Interaction.cs
@@ -39,22 +39,22 @@ namespace Avalonia.Xaml.Interactivity
         /// <summary>
         /// Gets or sets the <see cref="BehaviorCollection"/> associated with a specified object.
         /// </summary>
-        public static readonly AvaloniaProperty<BehaviorCollection> BehaviorsProperty =
-            AvaloniaProperty.RegisterAttached<Interaction, AvaloniaObject, BehaviorCollection>("Behaviors");
+        public static readonly AvaloniaProperty<BehaviorCollection?> BehaviorsProperty =
+            AvaloniaProperty.RegisterAttached<Interaction, AvaloniaObject, BehaviorCollection?>("Behaviors");
 
         /// <summary>
         /// Gets the <see cref="BehaviorCollection"/> associated with a specified object.
         /// </summary>
         /// <param name="obj">The <see cref="AvaloniaObject"/> from which to retrieve the <see cref="BehaviorCollection"/>.</param>
         /// <returns>A <see cref="BehaviorCollection"/> containing the behaviors associated with the specified object.</returns>
-        public static BehaviorCollection GetBehaviors(AvaloniaObject obj)
+        public static BehaviorCollection? GetBehaviors(AvaloniaObject obj)
         {
             if (obj == null)
             {
                 throw new ArgumentNullException(nameof(obj));
             }
 
-            BehaviorCollection behaviorCollection = obj.GetValue(BehaviorsProperty);
+            BehaviorCollection? behaviorCollection = obj.GetValue(BehaviorsProperty);
             if (behaviorCollection == null)
             {
                 behaviorCollection = new BehaviorCollection();
@@ -77,7 +77,7 @@ namespace Avalonia.Xaml.Interactivity
         /// </summary>
         /// <param name="obj">The <see cref="AvaloniaObject"/> on which to set the <see cref="BehaviorCollection"/>.</param>
         /// <param name="value">The <see cref="BehaviorCollection"/> associated with the object.</param>
-        public static void SetBehaviors(AvaloniaObject obj, BehaviorCollection value)
+        public static void SetBehaviors(AvaloniaObject obj, BehaviorCollection? value)
         {
             if (obj == null)
             {
@@ -93,7 +93,7 @@ namespace Avalonia.Xaml.Interactivity
         /// <param name="actions">The set of actions to execute.</param>
         /// <param name="parameter">The value of this parameter is determined by the calling behavior.</param>
         /// <returns>Returns the results of the actions.</returns>
-        public static IEnumerable<object> ExecuteActions(object? sender, ActionCollection? actions, object parameter)
+        public static IEnumerable<object> ExecuteActions(object? sender, ActionCollection? actions, object? parameter)
         {
             List<object> results = new List<object>();
 
@@ -119,7 +119,7 @@ namespace Avalonia.Xaml.Interactivity
         {
             if (sender is AvaloniaObject d)
             {
-                GetBehaviors(d).Attach(d);
+                GetBehaviors(d)?.Attach(d);
             }
         }
 
@@ -127,7 +127,7 @@ namespace Avalonia.Xaml.Interactivity
         {
             if (sender is AvaloniaObject d)
             {
-                GetBehaviors(d).Detach();
+                GetBehaviors(d)?.Detach();
             }
         }
     }

--- a/src/Avalonia.Xaml.Interactivity/Trigger.cs
+++ b/src/Avalonia.Xaml.Interactivity/Trigger.cs
@@ -13,22 +13,23 @@ namespace Avalonia.Xaml.Interactivity
         /// <summary>
         /// Identifies the <seealso cref="Actions"/> avalonia property.
         /// </summary>
-        public static readonly AvaloniaProperty<ActionCollection> ActionsProperty =
-            AvaloniaProperty.RegisterDirect<Trigger, ActionCollection>(nameof(Actions), t => t.Actions);
+        public static readonly AvaloniaProperty<ActionCollection?> ActionsProperty =
+            AvaloniaProperty.RegisterDirect<Trigger, ActionCollection?>(nameof(Actions), t => t.Actions);
 
-        private ActionCollection _actions;
+        private ActionCollection? _actions;
 
         /// <summary>
         /// Gets the collection of actions associated with the behavior. This is a avalonia property.
         /// </summary>
         [Content]
-        public ActionCollection Actions
+        public ActionCollection? Actions
         {
             get
             {
                 if (_actions == null)
+                {
                     _actions = new ActionCollection();
-
+                }
                 return _actions;
             }
         }

--- a/src/Avalonia.Xaml.Interactivity/TriggerOfT.cs
+++ b/src/Avalonia.Xaml.Interactivity/TriggerOfT.cs
@@ -15,7 +15,7 @@ namespace Avalonia.Xaml.Interactivity
         /// <summary>
         /// Gets the object to which this behavior is attached.
         /// </summary>
-        public new T AssociatedObject => base.AssociatedObject as T;
+        public new T? AssociatedObject => base.AssociatedObject as T;
 
         /// <summary>
         /// Called after the behavior is attached to the <see cref="Behavior.AssociatedObject"/>.
@@ -27,7 +27,7 @@ namespace Avalonia.Xaml.Interactivity
         {
             base.OnAttached();
 
-            if (AssociatedObject == null)
+            if (AssociatedObject == null && base.AssociatedObject != null)
             {
                 string actualType = base.AssociatedObject.GetType().FullName;
                 string expectedType = typeof(T).FullName;

--- a/tests/Avalonia.Xaml.Interactions.Custom.UnitTests/Avalonia.Xaml.Interactions.Custom.UnitTests.csproj
+++ b/tests/Avalonia.Xaml.Interactions.Custom.UnitTests/Avalonia.Xaml.Interactions.Custom.UnitTests.csproj
@@ -8,6 +8,7 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <Import Project="..\..\build\Rx.props" />

--- a/tests/Avalonia.Xaml.Interactions.UnitTests/Avalonia.Xaml.Interactions.UnitTests.csproj
+++ b/tests/Avalonia.Xaml.Interactions.UnitTests/Avalonia.Xaml.Interactions.UnitTests.csproj
@@ -8,6 +8,7 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <Import Project="..\..\build\Rx.props" />

--- a/tests/Avalonia.Xaml.Interactivity.UnitTests/Avalonia.Xaml.Interactivity.UnitTests.csproj
+++ b/tests/Avalonia.Xaml.Interactivity.UnitTests/Avalonia.Xaml.Interactivity.UnitTests.csproj
@@ -8,6 +8,7 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <GenerateRuntimeConfigurationFiles>True</GenerateRuntimeConfigurationFiles>
     <IsPackable>False</IsPackable>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <Import Project="..\..\build\Rx.props" />

--- a/tests/Avalonia.Xaml.Interactivity.UnitTests/StubAction.cs
+++ b/tests/Avalonia.Xaml.Interactivity.UnitTests/StubAction.cs
@@ -5,25 +5,25 @@ namespace Avalonia.Xaml.Interactivity.UnitTests
 {
     public class StubAction : AvaloniaObject, IAction
     {
-        private readonly object returnValue;
+        private readonly object? returnValue;
 
         public StubAction()
         {
             returnValue = null;
         }
 
-        public StubAction(object returnValue)
+        public StubAction(object? returnValue)
         {
             this.returnValue = returnValue;
         }
 
-        public object Sender
+        public object? Sender
         {
             get;
             private set;
         }
 
-        public object Parameter
+        public object? Parameter
         {
             get;
             private set;
@@ -35,7 +35,7 @@ namespace Avalonia.Xaml.Interactivity.UnitTests
             private set;
         }
 
-        public object Execute(object sender, object parameter)
+        public object? Execute(object? sender, object? parameter)
         {
             ExecuteCount++;
             Sender = sender;

--- a/tests/Avalonia.Xaml.Interactivity.UnitTests/StubBehavior.cs
+++ b/tests/Avalonia.Xaml.Interactivity.UnitTests/StubBehavior.cs
@@ -30,13 +30,13 @@ namespace Avalonia.Xaml.Interactivity.UnitTests
             Actions = new ActionCollection();
         }
 
-        public AvaloniaObject AssociatedObject
+        public AvaloniaObject? AssociatedObject
         {
             get;
             private set;
         }
 
-        public void Attach(AvaloniaObject avaloniaObject)
+        public void Attach(AvaloniaObject? avaloniaObject)
         {
             AssociatedObject = avaloniaObject;
             AttachCount++;

--- a/tests/Avalonia.Xaml.Interactivity.UnitTests/TestUitilties.cs
+++ b/tests/Avalonia.Xaml.Interactivity.UnitTests/TestUitilties.cs
@@ -32,7 +32,7 @@ namespace Avalonia.Xaml.Interactivity.UnitTests
             Assert.Equal(0, behavior.DetachCount); // "The Behavior should not be detached."
         }
 
-        public static void AssertAttached(StubBehavior behavior, AvaloniaObject associatedObject)
+        public static void AssertAttached(StubBehavior behavior, AvaloniaObject? associatedObject)
         {
             Assert.Equal(1, behavior.AttachCount); // "The behavior should be attached."
             Assert.Equal(associatedObject, behavior.AssociatedObject); // "The AssociatedObject of the Behavior should be what it was attached to."


### PR DESCRIPTION
Fixes #21 

### Projects

- [x] Avalonia.Xaml.Interactivity
- [x] Avalonia.Xaml.Interactions
- [x] Avalonia.Xaml.Behaviors
- [x] Avalonia.Xaml.Interactions.Custom
- [x] Avalonia.Xaml.Interactivity.UnitTests
- [x] Avalonia.Xaml.Interactions.UnitTests
- [x] Avalonia.Xaml.Interactions.Custom.UnitTests
- [x] BehaviorsTestApplication
- [x] BehaviorsTestApplication.NetCore