### PR TITLE
Add OnAttachedToVisualTree and OnDetachedFromVisualTree methods to Behavior

### DIFF
--- a/src/Avalonia.Xaml.Interactions/Draggable/ItemDragBehavior.cs
+++ b/src/Avalonia.Xaml.Interactions/Draggable/ItemDragBehavior.cs
@@ -165,7 +165,7 @@ public class ItemDragBehavior : Behavior<IControl>
         {
             if (_draggedIndex >= 0 && _targetIndex >= 0 && _draggedIndex != _targetIndex)
             {
-                Debug.WriteLine($"MoveItem {_draggedIndex} -> {_targetIndex}");
+                // Debug.WriteLine($"MoveItem {_draggedIndex} -> {_targetIndex}");
                 MoveDraggedItem(_itemsControl, _draggedIndex, _targetIndex);
             }
         }
@@ -354,7 +354,7 @@ public class ItemDragBehavior : Behavior<IControl>
 
                     _targetIndex = _targetIndex == -1 ? targetIndex :
                         targetIndex > _targetIndex ? targetIndex : _targetIndex;
-                    Debug.WriteLine($"Moved Right {_draggedIndex} -> {_targetIndex}");
+                    // Debug.WriteLine($"Moved Right {_draggedIndex} -> {_targetIndex}");
                 }
                 else if (targetStart < draggedStart && draggedDeltaStart <= targetMid)
                 {
@@ -369,7 +369,7 @@ public class ItemDragBehavior : Behavior<IControl>
 
                     _targetIndex = _targetIndex == -1 ? targetIndex :
                         targetIndex < _targetIndex ? targetIndex : _targetIndex;
-                    Debug.WriteLine($"Moved Left {_draggedIndex} -> {_targetIndex}");
+                    // Debug.WriteLine($"Moved Left {_draggedIndex} -> {_targetIndex}");
                 }
                 else
                 {
@@ -386,7 +386,7 @@ public class ItemDragBehavior : Behavior<IControl>
                 i++;
             }
 
-            Debug.WriteLine($"Moved {_draggedIndex} -> {_targetIndex}");
+            // Debug.WriteLine($"Moved {_draggedIndex} -> {_targetIndex}");
         }
     }
 

--- a/src/Avalonia.Xaml.Interactivity/Behavior.cs
+++ b/src/Avalonia.Xaml.Interactivity/Behavior.cs
@@ -57,6 +57,7 @@ public abstract class Behavior : AvaloniaObject, IBehavior
     /// </remarks>
     protected virtual void OnAttached()
     {
+        // Debug.WriteLine($"[OnAttached] {this}, {AssociatedObject}");
     }
 
     /// <summary>
@@ -67,6 +68,7 @@ public abstract class Behavior : AvaloniaObject, IBehavior
     /// </remarks>
     protected virtual void OnDetaching()
     {
+        // Debug.WriteLine($"[OnDetaching] {this}, {AssociatedObject}");
     }
 
     internal void AttachedToVisualTree()
@@ -87,7 +89,7 @@ public abstract class Behavior : AvaloniaObject, IBehavior
     /// </remarks>
     protected virtual void OnAttachedToVisualTree()
     {
-        // Debug.WriteLine($"OnAttachedToVisualTree {this}");
+        // Debug.WriteLine($"[OnAttachedToVisualTree] {this}, {AssociatedObject}");
     }
 
     /// <summary>
@@ -98,6 +100,6 @@ public abstract class Behavior : AvaloniaObject, IBehavior
     /// </remarks>
     protected virtual void OnDetachedFromVisualTree()
     {
-        // Debug.WriteLine($"OnDetachedFromVisualTree {this}");
+        // Debug.WriteLine($"[OnDetachedFromVisualTree] {this}, {AssociatedObject}");
     }
 }

--- a/src/Avalonia.Xaml.Interactivity/Behavior.cs
+++ b/src/Avalonia.Xaml.Interactivity/Behavior.cs
@@ -87,6 +87,7 @@ public abstract class Behavior : AvaloniaObject, IBehavior
     /// </remarks>
     protected virtual void OnAttachedToVisualTree()
     {
+        // Debug.WriteLine($"OnAttachedToVisualTree {this}");
     }
 
     /// <summary>
@@ -97,5 +98,6 @@ public abstract class Behavior : AvaloniaObject, IBehavior
     /// </remarks>
     protected virtual void OnDetachedFromVisualTree()
     {
+        // Debug.WriteLine($"OnDetachedFromVisualTree {this}");
     }
 }

--- a/src/Avalonia.Xaml.Interactivity/Behavior.cs
+++ b/src/Avalonia.Xaml.Interactivity/Behavior.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Globalization;
+using Avalonia.Controls;
 
 namespace Avalonia.Xaml.Interactivity;
 
@@ -65,6 +66,36 @@ public abstract class Behavior : AvaloniaObject, IBehavior
     /// Override this to unhook functionality from the <see cref="AssociatedObject"/>
     /// </remarks>
     protected virtual void OnDetaching()
+    {
+    }
+
+    internal void AttachedToVisualTree()
+    {
+        OnAttachedToVisualTree();
+    }
+
+    internal void DetachedFromVisualTree()
+    {
+        OnDetachedFromVisualTree();
+    }
+
+    /// <summary>
+    /// Called after the <see cref="AssociatedObject"/> is attached to the visual tree.
+    /// </summary>
+    /// <remarks>
+    /// Invoked only when the <see cref="AssociatedObject"/> is of type <see cref="IControl"/>.
+    /// </remarks>
+    protected virtual void OnAttachedToVisualTree()
+    {
+    }
+
+    /// <summary>
+    /// Called when the <see cref="AssociatedObject"/> is being detached from the visual tree.
+    /// </summary>
+    /// <remarks>
+    /// Invoked only when the <see cref="AssociatedObject"/> is of type <see cref="IControl"/>.
+    /// </remarks>
+    protected virtual void OnDetachedFromVisualTree()
     {
     }
 }

--- a/src/Avalonia.Xaml.Interactivity/BehaviorCollection.cs
+++ b/src/Avalonia.Xaml.Interactivity/BehaviorCollection.cs
@@ -99,8 +99,6 @@ public class BehaviorCollection : AvaloniaList<IAvaloniaObject>
         }
     }
 
-    
-    
     private void BehaviorCollection_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs eventArgs)
     {
         if (eventArgs.Action == NotifyCollectionChangedAction.Reset)

--- a/src/Avalonia.Xaml.Interactivity/BehaviorCollection.cs
+++ b/src/Avalonia.Xaml.Interactivity/BehaviorCollection.cs
@@ -77,6 +77,30 @@ public class BehaviorCollection : AvaloniaList<IAvaloniaObject>
         _oldCollection.Clear();
     }
 
+    internal void AttachedToVisualTree()
+    {
+        foreach (var item in this)
+        {
+            if (item is Behavior behavior)
+            {
+                behavior.AttachedToVisualTree();
+            }
+        }
+    }
+
+    internal void DetachedFromVisualTree()
+    {
+        foreach (var item in this)
+        {
+            if (item is Behavior behavior && behavior.AssociatedObject is { })
+            {
+                behavior.DetachedFromVisualTree();
+            }
+        }
+    }
+
+    
+    
     private void BehaviorCollection_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs eventArgs)
     {
         if (eventArgs.Action == NotifyCollectionChangedAction.Reset)

--- a/src/Avalonia.Xaml.Interactivity/BehaviorCollection.cs
+++ b/src/Avalonia.Xaml.Interactivity/BehaviorCollection.cs
@@ -103,6 +103,7 @@ public class BehaviorCollection : AvaloniaList<IAvaloniaObject>
     {
         if (eventArgs.Action == NotifyCollectionChangedAction.Reset)
         {
+            // Debug.WriteLine($"[BehaviorCollection_CollectionChanged] Reset");
             foreach (var behavior in _oldCollection)
             {
                 if (behavior.AssociatedObject is { })
@@ -127,6 +128,7 @@ public class BehaviorCollection : AvaloniaList<IAvaloniaObject>
         {
             case NotifyCollectionChangedAction.Add:
             {
+                // Debug.WriteLine($"[BehaviorCollection_CollectionChanged] Add");
                 var eventIndex = eventArgs.NewStartingIndex;
                 var changedItem = eventArgs.NewItems?[0] as IAvaloniaObject;
                 _oldCollection.Insert(eventIndex, VerifiedAttach(changedItem));
@@ -135,6 +137,7 @@ public class BehaviorCollection : AvaloniaList<IAvaloniaObject>
 
             case NotifyCollectionChangedAction.Replace:
             {
+                // Debug.WriteLine($"[BehaviorCollection_CollectionChanged] Replace");
                 var eventIndex = eventArgs.OldStartingIndex;
                 eventIndex = eventIndex == -1 ? 0 : eventIndex;
 
@@ -152,6 +155,7 @@ public class BehaviorCollection : AvaloniaList<IAvaloniaObject>
 
             case NotifyCollectionChangedAction.Remove:
             {
+                // Debug.WriteLine($"[BehaviorCollection_CollectionChanged] Remove");
                 var eventIndex = eventArgs.OldStartingIndex;
 
                 var oldItem = _oldCollection[eventIndex];

--- a/src/Avalonia.Xaml.Interactivity/Interaction.cs
+++ b/src/Avalonia.Xaml.Interactivity/Interaction.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using Avalonia.Controls;
 
 namespace Avalonia.Xaml.Interactivity;
@@ -140,7 +141,9 @@ public class Interaction
     {
         if (sender is IAvaloniaObject d)
         {
+            // Debug.WriteLine($"[Control_AttachedToVisualTree1] Attach() {sender}");
             GetBehaviors(d).Attach(d);
+            // Debug.WriteLine($"[Control_AttachedToVisualTree1] AttachedToVisualTree() {sender}");
             GetBehaviors(d).AttachedToVisualTree();
         }
     }
@@ -149,7 +152,9 @@ public class Interaction
     {
         if (sender is IAvaloniaObject d)
         {
+            // Debug.WriteLine($"[Control_DetachedFromVisualTree1] DetachedFromVisualTree() {sender}");
             GetBehaviors(d).DetachedFromVisualTree();
+            // Debug.WriteLine($"[Control_DetachedFromVisualTree1] Detach() {sender}");
             GetBehaviors(d).Detach();
         }
     }
@@ -158,6 +163,7 @@ public class Interaction
     {
         if (sender is IAvaloniaObject d)
         {
+            // Debug.WriteLine($"[Control_AttachedToVisualTree2] AttachedToVisualTree() {sender}");
             GetBehaviors(d).AttachedToVisualTree();
         }
     }
@@ -166,6 +172,7 @@ public class Interaction
     {
         if (sender is IAvaloniaObject d)
         {
+            // Debug.WriteLine($"[Control_DetachedFromVisualTree2] DetachedFromVisualTree() {sender}");
             GetBehaviors(d).DetachedFromVisualTree();
         }
     }

--- a/src/Avalonia.Xaml.Interactivity/Interaction.cs
+++ b/src/Avalonia.Xaml.Interactivity/Interaction.cs
@@ -149,8 +149,8 @@ public class Interaction
     {
         if (sender is IAvaloniaObject d)
         {
-            GetBehaviors(d).Detach();
             GetBehaviors(d).DetachedFromVisualTree();
+            GetBehaviors(d).Detach();
         }
     }
  

--- a/src/Avalonia.Xaml.Interactivity/Interaction.cs
+++ b/src/Avalonia.Xaml.Interactivity/Interaction.cs
@@ -29,6 +29,7 @@ public class Interaction
             if (newCollection is { })
             {
                 newCollection.Attach(e.Sender);
+                SetVisualTreeEventHandlers2(e.Sender);
             }
         });
     }
@@ -44,7 +45,7 @@ public class Interaction
     /// </summary>
     /// <param name="obj">The <see cref="IAvaloniaObject"/> from which to retrieve the <see cref="BehaviorCollection"/>.</param>
     /// <returns>A <see cref="BehaviorCollection"/> containing the behaviors associated with the specified object.</returns>
-    public static BehaviorCollection? GetBehaviors(IAvaloniaObject obj)
+    public static BehaviorCollection GetBehaviors(IAvaloniaObject obj)
     {
         if (obj is null)
         {
@@ -56,17 +57,38 @@ public class Interaction
         {
             behaviorCollection = new BehaviorCollection();
             obj.SetValue(BehaviorsProperty, behaviorCollection);
-
-            if (obj is Control control)
-            {
-                control.AttachedToVisualTree -= Control_AttachedToVisualTree;
-                control.AttachedToVisualTree += Control_AttachedToVisualTree;
-                control.DetachedFromVisualTree -= Control_DetachedFromVisualTree;
-                control.DetachedFromVisualTree += Control_DetachedFromVisualTree;
-            }
+            SetVisualTreeEventHandlers1(obj);
         }
 
         return behaviorCollection;
+    }
+
+    private static void SetVisualTreeEventHandlers1(IAvaloniaObject obj)
+    {
+        if (obj is Control control)
+        {
+            control.AttachedToVisualTree -= Control_AttachedToVisualTree2;
+            control.DetachedFromVisualTree -= Control_DetachedFromVisualTree2;
+
+            control.AttachedToVisualTree -= Control_AttachedToVisualTree1;
+            control.AttachedToVisualTree += Control_AttachedToVisualTree1;
+            control.DetachedFromVisualTree -= Control_DetachedFromVisualTree1;
+            control.DetachedFromVisualTree += Control_DetachedFromVisualTree1;
+        }
+    }
+
+    private static void SetVisualTreeEventHandlers2(IAvaloniaObject obj)
+    {
+        if (obj is Control control)
+        {
+            control.AttachedToVisualTree -= Control_AttachedToVisualTree1;
+            control.DetachedFromVisualTree -= Control_DetachedFromVisualTree1;
+
+            control.AttachedToVisualTree -= Control_AttachedToVisualTree2;
+            control.AttachedToVisualTree += Control_AttachedToVisualTree2;
+            control.DetachedFromVisualTree -= Control_DetachedFromVisualTree2;
+            control.DetachedFromVisualTree += Control_DetachedFromVisualTree2;
+        }
     }
 
     /// <summary>
@@ -114,19 +136,37 @@ public class Interaction
         return results;
     }
 
-    private static void Control_AttachedToVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    private static void Control_AttachedToVisualTree1(object? sender, VisualTreeAttachmentEventArgs e)
     {
         if (sender is IAvaloniaObject d)
         {
-            GetBehaviors(d)?.Attach(d);
+            GetBehaviors(d).Attach(d);
+            GetBehaviors(d).AttachedToVisualTree();
         }
     }
 
-    private static void Control_DetachedFromVisualTree(object? sender, VisualTreeAttachmentEventArgs e)
+    private static void Control_DetachedFromVisualTree1(object? sender, VisualTreeAttachmentEventArgs e)
     {
         if (sender is IAvaloniaObject d)
         {
-            GetBehaviors(d)?.Detach();
+            GetBehaviors(d).Detach();
+            GetBehaviors(d).DetachedFromVisualTree();
+        }
+    }
+ 
+    private static void Control_AttachedToVisualTree2(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        if (sender is IAvaloniaObject d)
+        {
+            GetBehaviors(d).AttachedToVisualTree();
+        }
+    }
+
+    private static void Control_DetachedFromVisualTree2(object? sender, VisualTreeAttachmentEventArgs e)
+    {
+        if (sender is IAvaloniaObject d)
+        {
+            GetBehaviors(d).DetachedFromVisualTree();
         }
     }
 }


### PR DESCRIPTION
It solves issue when control is attached/detached several times from/to visual tree. It is hard to get proper event handlers for attached/detached visual tree as after initial attachment the second time it’s attached it is from AttachedToVisualTree event.