### PR TITLE
Handle properly attached properties in ChangePropertyAction

### DIFF
--- a/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
+++ b/src/Avalonia.Xaml.Interactions/Core/ChangePropertyAction.cs
@@ -29,14 +29,11 @@ public class ChangePropertyAction : AvaloniaObject, IAction
         {
             return null;
         }
-        if (propertyNames[0] != targetType.Name)
-        {
-            return null;
-        }
         for (var i = 0; i < registeredAttachedCount; i++)
         {
             var avaloniaProperty = registeredAttached[i];
-            if (avaloniaProperty.Name == propertyNames[1])
+            if (avaloniaProperty.OwnerType.Name == propertyNames[0] 
+                && avaloniaProperty.Name == propertyNames[1])
             {
                 return avaloniaProperty;
             }


### PR DESCRIPTION
```XAML
<UserControl x:Class="BehaviorsTestApplication.Views.Pages.ChangePropertyActionView"
             xmlns="https://github.com/avaloniaui"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
             xmlns:ia="clr-namespace:Avalonia.Xaml.Interactions.Core;assembly=Avalonia.Xaml.Interactions"
             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
             mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450">
  <Panel>
    <Button Name="SampleButton" 
            ToolTip.Tip="Even" 
            Content="Hover over to see ToolTip, click to change ToolTip" 
            VerticalAlignment="Center" HorizontalAlignment="Center">
      <i:Interaction.Behaviors>
        <ia:EventTriggerBehavior EventName="Click" SourceObject="SampleButton">
          <ia:ChangePropertyAction TargetObject="SampleButton" 
                                   PropertyName="ToolTip.Tip"
                                   Value="Odd" />
        </ia:EventTriggerBehavior>
      </i:Interaction.Behaviors>
    </Button>
  </Panel>
</UserControl>

```